### PR TITLE
Use latest release of workflow extender

### DIFF
--- a/tests/warmup-manifest-build.yml
+++ b/tests/warmup-manifest-build.yml
@@ -13,7 +13,7 @@ jobs:
     fetch: http
     username: NEXUS_USERNAME
     password: NEXUS_PASSWORD
-    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.modules&a=workflow-extender&v=LATEST
+    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-enterprise-releases&g=org.jahia.modules&a=workflow-extender&v=LATEST
     filepath: /tmp/workflow-extender-LATEST.jar
   - type: module
     id: workflow-extender

--- a/tests/warmup-manifest-snapshot.yml
+++ b/tests/warmup-manifest-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     fetch: http
     username: NEXUS_USERNAME
     password: NEXUS_PASSWORD
-    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-enterprise-snapshots&g=org.jahia.modules&a=workflow-extender&v=LATEST
+    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-enterprise-releases&g=org.jahia.modules&a=workflow-extender&v=LATEST
     filepath: /tmp/workflow-extender-LATEST.jar
   - type: module
     id: workflow-extender


### PR DESCRIPTION
Updated manifests to download the latest release of workflow extender for both the build and snapshot tests of scheduled publication workflow.